### PR TITLE
moving a word

### DIFF
--- a/wordfilter_onlyifstandalone
+++ b/wordfilter_onlyifstandalone
@@ -64,3 +64,4 @@ pube
 pubes
 twat
 retards
+rimming

--- a/worldfilter_blanketbanned
+++ b/worldfilter_blanketbanned
@@ -191,7 +191,6 @@ pussy
 pussys
 rectum
 rimjaw
-rimming
 sadist
 schlong
 scrotum


### PR DESCRIPTION
The word rimming is blanket banned, moving it to standalone for words like trimming. Thank you english.